### PR TITLE
fix make_var_som_mx6_debian.sh

### DIFF
--- a/make_var_som_mx6_debian.sh
+++ b/make_var_som_mx6_debian.sh
@@ -39,14 +39,14 @@ readonly G_VARISCITE_PATH="${DEF_BUILDENV}/variscite"
 ## LINUX kernel: git, config, paths and etc
 readonly G_LINUX_KERNEL_SRC_DIR="${DEF_SRC_DIR}/kernel"
 readonly G_LINUX_KERNEL_GIT="https://github.com/varigit/linux-2.6-imx.git"
-readonly G_LINUX_KERNEL_BRANCH="imx-rel_imx_4.1.15_2.0.0_ga-var03"
+readonly G_LINUX_KERNEL_BRANCH="imx-rel_imx_4.1.15_2.0.0_ga-var02"
 readonly G_LINUX_KERNEL_DEF_CONFIG="imx_v7_var_defconfig"
 readonly G_LINUX_DTB="imx6dl-var-som-cap.dtb imx6dl-var-som-res.dtb imx6dl-var-som-solo-cap.dtb imx6dl-var-som-solo-res.dtb imx6dl-var-som-solo-vsc.dtb imx6dl-var-som-vsc.dtb imx6q-var-dart.dtb imx6q-var-som-cap.dtb imx6q-var-som-res.dtb imx6q-var-som-vsc.dtb"
 
 ## uboot
 readonly G_UBOOT_SRC_DIR="${DEF_SRC_DIR}/uboot"
 readonly G_UBOOT_GIT="https://github.com/varigit/uboot-imx.git"
-readonly G_UBOOT_BRANCH="imx_v2015.04_4.1.15_1.1.0_ga_var01"
+readonly G_UBOOT_BRANCH="imx_v2015.04_4.1.15_1.1.0_ga_var03"
 readonly G_UBOOT_DEF_CONFIG_MMC="mx6var_som_sd_config"
 readonly G_UBOOT_NAME_FOR_EMMC="u-boot.img.mmc"
 readonly G_SPL_NAME_FOR_EMMC="SPL.mmc"


### PR DESCRIPTION
I assume that c6be67b should have changed the u-boot branch rather than the kernel branch so I fixed both lines so that they point to the latest branches respectively.